### PR TITLE
Publish docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.github
+deployments
+docs
+examples
+.gitignore
+beaver
+beaver_server
+Makefile
+README.md

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@
 build-server:
 	go build -ldflags="-s -w" -o beaver_server ./cmd/beaver_server
 
+build-server-image:
+	docker buildx build --platform linux/amd64,linux/arm64 -t amalshaji/beaver:latest -f deployments/Dockerfile --push .
+
 build-client:
 	go build -ldflags="-s -w" -o beaver ./cmd/beaver_client
 
 run-test-server:
 	go run ./examples/test_api/main.go
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/beaver.png" height="250px">
 
-## Client Setup
+## Client
 
 Download the binary from releases or build from source. Refer `Makefile` for client build command. You may have to build for your architecture.
 
@@ -25,9 +25,11 @@ poolmaxsize : 100         # Maximum number of concurrent open (TCP) connections 
 secretkey : ThisIsASecret # Users secret key set in the server config
 ```
 
-## Server Setup
+## Server
 
-Download the server binary from the releases or use the docker image provided.
+```bash
+docker pull amalshaji/beaver:latest
+```
 
 ### Config file for server
 

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -1,12 +1,21 @@
 FROM golang:1.19 AS builder
+
 WORKDIR /app
+
 COPY go.mod go.sum /app/
+
 RUN go mod download
+
 COPY . /app/
+
 RUN go build -ldflags="-s -w" -o beaver_server ./cmd/beaver_server
 
 FROM alpine:3.17.1  
+
 WORKDIR /app
-RUN apk add libc6-compat
+
+RUN apk add libc6-compat=1.2.3-r4 --no-cache && rm -rf /var/cache/apk/*
+
 COPY --from=builder /app/beaver_server /app/
+
 ENTRYPOINT ["./beaver_server"]

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/amalshaji/beaver
 
-go 1.20
+go 1.19
 
 require (
-	github.com/gorilla/websocket v1.4.2
+	github.com/gorilla/websocket v1.5.0
 	github.com/labstack/echo/v4 v4.10.0
 	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
- Revert to go 1.19
- Update and publish docker image `amalshaji/beaver:latest`
- Update docs
- Upgrade websocket package