### PR TITLE
Mount server config directory in dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,38 +15,86 @@ Usage:
       --port int           Local http server port (required)
 ```
 
-### Config
+#### Example
+
+```shell
+➜  beaver git:(main) ✗ ./beaver --config docs/beaver_client.yaml --port 8000
+2023/02/05 19:46:07 Creating tunnel connection
+2023/02/05 19:46:07 Tunnel running on https://sccrej.tunnel.example.com
+```
+
+Now, `https://sccrej.tunnel.example.com ⇄ http://localhost:8000`
+
+#### Config
 
 ```yaml
-targets :                 # Beaver server url (eg: wss://tunnel.example.com)
- - ws://127.0.0.1:8080
-poolidlesize : 1          # Default number of concurrent open (TCP) connections to keep idle per WSP server(optional)
-poolmaxsize : 100         # Maximum number of concurrent open (TCP) connections per WSP server(optional)
-secretkey : ThisIsASecret # Users secret key set in the server config
+targets:                 
+  - ws://127.0.0.1:8080    # Beaver server url (eg: wss://tunnel.example.com)
+poolidlesize: 1            # Default number of concurrent open (TCP) connections to keep idle per WSP server(optional)
+poolmaxsize: 100           # Maximum number of concurrent open (TCP) connections per WSP server(optional)
+secretkey: ThisIsASecret   # User's secret key set in the server config
 ```
 
 ## Server
 
 Download the binary from [releases page](https://github.com/amalshaji/beaver/releases), or use the [docker image](https://hub.docker.com/r/amalshaji/beaver)
 
-### Config
+#### Deploy
+
+1. Using the binary
+
+    ```shell
+    ./beaver_server --config docs/beaver_server.yaml
+    ```
+
+1. Using docker
+
+    ```shell
+    docker run \
+      -v $PWD/docs/beaver_server.yaml:/app/config/beaver_server.yaml \
+      -p 8080:8080 amalshaji/beaver:latest
+    ```
+
+    Replace `$PWD/docs/beaver_server.yaml` with path to your config file
+
+1. Using docker compose
+
+    ```yaml
+    services:
+      beaver:
+        image: amalshaji/beaver:latest
+        volumes:
+          - ./docs/beaver_server.yaml:/app/config/beaver_server.yaml
+        ports:
+          - 8080:8080
+        restart: unless-stopped
+    ```
+
+    Start the server:
+
+    ```shell
+    docker compose up -d
+    ```
+
+#### Config
 
 ```yaml
-host : 127.0.0.1             # Address to bind the HTTP server
-port : 8080                  # Port to bind the HTTP server
-timeout : 3000               # Time to wait before acquiring a WS connection to forward the request (milliseconds, optional)
-idletimeout : 60000          # Time to wait before closing idle connection when there is enough idle connections (milliseconds, optional)
-users:                       # User specific secret keys
+host : 0.0.0.0                  # Address to bind the HTTP server
+port : 8080                     # Port to bind the HTTP server
+domain: localhost               # Domain on which the server will be running (eg: tunnel.example.com)            
+secure: false                   # Whether the server runs under https
+timeout : 3000                  # Time to wait before acquiring a WS connection to forward the request (milliseconds)
+idletimeout : 60000             # Time to wait before closing idle connection when there is enough idle connections (milliseconds)
+users:
   - identifier: foo@bar.com
     secretkey: ThisIsASecret
   - identifier: max@xam.com
     secretkey: ThisIsASecret@2
+
 ```
 
 ## Credits
 
 This project is a fork of [hgsgtk/wsp](https://github.com/hgsgtk/wsp)
 
-
-## Checkout [wiki](https://github.com/amalshaji/beaver/wiki) for examples and tutorials
-
+## Checkout [wiki](https://github.com/amalshaji/beaver/wiki) for examples

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -18,4 +18,6 @@ RUN apk add libc6-compat=1.2.3-r4 --no-cache && rm -rf /var/cache/apk/*
 
 COPY --from=builder /app/beaver_server /app/
 
-ENTRYPOINT ["./beaver_server"]
+VOLUME [ "/app/config" ]
+
+ENTRYPOINT ["./beaver_server", "--config", "/app/config/beaver_server.yaml"]

--- a/docs/beaver_server.yaml
+++ b/docs/beaver_server.yaml
@@ -1,6 +1,6 @@
 host : 0.0.0.0                     # Address to bind the HTTP server
 port : 8080                        # Port to bind the HTTP server
-domain: localhost                  # Domain where the server will be running            
+domain: localhost                  # Domain on which the server will be running (eg: tunnel.example.com)            
 secure: false                      # Whether the server runs under https
 timeout : 3000                     # Time to wait before acquiring a WS connection to forward the request (milliseconds)
 idletimeout : 60000                # Time to wait before closing idle connection when there is enough idle connections (milliseconds)


### PR DESCRIPTION
- Mount the `/app/config` directory https://github.com/amalshaji/beaver/blob/0a63c93957f7c99a189d2ac86a6f0db9e00565d9/deployments/Dockerfile#L21
- The server config file is set to `/app/config/beaver_server.yaml` https://github.com/amalshaji/beaver/blob/0a63c93957f7c99a189d2ac86a6f0db9e00565d9/deployments/Dockerfile#L23

Now, users can directly pass in the config file as 

```shell
docker run \
  -v $PWD/docs/beaver_server.yaml:/app/config/beaver_server.yaml \
  -p 8080:8080 amalshaji/beaver:latest
```