### PR TITLE
Add support for multiple tunnels simultaneously

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,51 +1,51 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - name: Install pnpm
-      run: npm i -g pnpm
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
-        cache: 'pnpm'
-    - name: Install dependencies
-      run: pnpm install
-    - name: Install Playwright Browsers
-      run: pnpm dlx playwright install --with-deps
-    - name: Add hosts to /etc/hosts
-      run: |
+      - name: Install pnpm
+        run: npm i -g pnpm
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Playwright Browsers
+        run: pnpm dlx playwright install --with-deps
+      - name: Add hosts to /etc/hosts
+        run: |
           sudo echo "127.0.0.1 test.localhost" | sudo tee -a /etc/hosts
-    - name: Build client and server
-      run: |
+      - name: Build client and server
+        run: |
           go build -ldflags="-s -w" -o beaver ./cmd/beaver_client
           go build -ldflags="-s -w" -o beaver_server ./cmd/beaver_server
           go build -ldflags="-s -w" -o test_server ./e2e/server.go
-    - name: Start test servers
-      run: |
+      - name: Start test servers
+        run: |
           ./test_server &
           sleep 5
           ./beaver_server --config docs/beaver_server.yaml &
           sleep 5
-    - name: Start test client
-      run: |
-          ./beaver --config docs/beaver_client.yaml --port 9999 --subdomain test &
+      - name: Start test client
+        run: |
+          ./beaver --config docs/beaver_client.yaml http 9999 --subdomain test &
           sleep 3
-    - name: Run Playwright tests
-      run: pnpm dlx playwright test
-    - name: Kill test servers
-      run: |
+      - name: Run Playwright tests
+        run: pnpm dlx playwright test
+      - name: Kill test servers
+        run: |
           make kill-test-servers
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules
 /playwright/.cache/
 
 dist/
+!beaver_server/

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ start-test-servers:
 	@go run cmd/beaver_server/main.go --config docs/beaver_server.yaml &
 	@sleep 5
 	@echo "Starting beaver client"
-	@go run cmd/beaver_client/main.go --config docs/beaver_client.yaml --port 9999 --subdomain test &
+	@go run cmd/beaver_client/main.go --config docs/beaver_client.yaml http 9999 --subdomain test &
 	@sleep 5
 
 kill-test-servers:

--- a/README.md
+++ b/README.md
@@ -7,12 +7,48 @@
 Download the binary from [releases page](https://github.com/amalshaji/beaver/releases).
 
 ```bash
-beaver - tunnel local ports to public URLs:
+➜  beaver --help
+Tunnel local ports to public URLs
 
 Usage:
-      --config string      Config file path (default "/Users/amalshaji/.beaver/beaver_client.yaml")
+  beaver [flags]
+  beaver [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  http        Tunnel local http servers
+  start       Start tunnels defined in the config file
+
+Flags:
+      --config string   Path to the client config file (default "/Users/amalshaji/.beaver/beaver_client.yaml")
+  -h, --help            help for beaver
+
+Use "beaver [command] --help" for more information about a command.
+
+---
+
+➜  beaver http --help
+Tunnel local http servers
+
+Usage:
+  beaver http [PORT] [flags]
+
+Flags:
+  -h, --help               help for http
       --subdomain string   Subdomain to tunnel http requests (default "<random_subdomain>")
-      --port int           Local http server port (required)
+
+---
+
+➜  beaver start --help
+Start tunnels defined in the config file
+
+Usage:
+  beaver start [--all] or [tunnel1 tunnel2] [flags]
+
+Flags:
+      --all    Start all tunnels listed in the config
+  -h, --help   help for start
 ```
 
 #### Example
@@ -23,7 +59,7 @@ Usage:
 2023/02/05 19:46:07 Tunnel running on https://sccrej.tunnel.example.com
 ```
 
-Now, `https://sccrej.tunnel.example.com ⇄ http://localhost:8000`
+Now, `https://sccrej.tunnel.example.com -> http://localhost:8000`
 
 #### Config
 

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ import (
 // Client connects to one or more Server using HTTP websockets.
 // The Server can then send HTTP requests to execute.
 type Client struct {
-	Proxy *Proxy
+	Config *Config
 
 	client *http.Client
 	dialer *websocket.Dialer
@@ -18,9 +18,9 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(config *Proxy) (c *Client) {
+func NewClient(config *Config) (c *Client) {
 	c = new(Client)
-	c.Proxy = config
+	c.Config = config
 	c.client = &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
@@ -33,11 +33,9 @@ func NewClient(config *Proxy) (c *Client) {
 
 // Start the Proxy
 func (c *Client) Start(ctx context.Context) {
-	for _, target := range c.Proxy.Config.Targets {
-		pool := NewPool(c, target)
-		c.pools[target] = pool
-		go pool.Start(ctx)
-	}
+	pool := NewPool(c, c.Config.Target)
+	c.pools[c.Config.Target] = pool
+	go pool.Start(ctx)
 }
 
 // Shutdown the Proxy

--- a/client/client.go
+++ b/client/client.go
@@ -34,7 +34,7 @@ func NewClient(config *Config) (c *Client) {
 // Start the Proxy
 func (c *Client) Start(ctx context.Context) {
 	pool := NewPool(c, c.Config.Target)
-	c.pools[c.Config.Target] = pool
+	c.pools[c.Config.id] = pool
 	go pool.Start(ctx)
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ import (
 // Client connects to one or more Server using HTTP websockets.
 // The Server can then send HTTP requests to execute.
 type Client struct {
-	Config *Config
+	Proxy *Proxy
 
 	client *http.Client
 	dialer *websocket.Dialer
@@ -18,9 +18,9 @@ type Client struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(config *Config) (c *Client) {
+func NewClient(config *Proxy) (c *Client) {
 	c = new(Client)
-	c.Config = config
+	c.Proxy = config
 	c.client = &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
@@ -33,7 +33,7 @@ func NewClient(config *Config) (c *Client) {
 
 // Start the Proxy
 func (c *Client) Start(ctx context.Context) {
-	for _, target := range c.Config.Targets {
+	for _, target := range c.Proxy.Config.Targets {
 		pool := NewPool(c, target)
 		c.pools[target] = pool
 		go pool.Start(ctx)

--- a/client/config.go
+++ b/client/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	port             int
 	showWsReadErrors bool
 
-	Target       string `yaml:"target"`
+	Target       string
 	PoolIdleSize int
 	PoolMaxSize  int
 	SecretKey    string

--- a/client/config.go
+++ b/client/config.go
@@ -31,17 +31,22 @@ type Proxy struct {
 	Tunnels []TunnelConfig
 }
 
-// NewConfig creates a new ProxyConfig
-func (config *Proxy) setDefaults() {
+func (proxy *Proxy) setDefaults() {
 	id, err := uuid.NewV4()
 	if err != nil {
 		panic(err)
 	}
-	config.id = id.String()
+	proxy.id = id.String()
 
-	config.Config.Targets = []string{"wss://x.amal.sh"}
-	config.Config.PoolIdleSize = 1
-	config.Config.PoolMaxSize = 100
+	if len(proxy.Config.Targets) == 0 {
+		proxy.Config.Targets = []string{"wss://x.amal.sh"}
+	}
+	if proxy.Config.PoolIdleSize == 0 {
+		proxy.Config.PoolIdleSize = 1
+	}
+	if proxy.Config.PoolMaxSize == 0 {
+		proxy.Config.PoolMaxSize = 100
+	}
 
 }
 

--- a/client/config.go
+++ b/client/config.go
@@ -1,10 +1,13 @@
 package client
 
 import (
+	"os"
 	"strings"
 
 	gonanoid "github.com/matoous/go-nanoid/v2"
 	uuid "github.com/nu7hatch/gouuid"
+
+	"gopkg.in/yaml.v3"
 )
 
 type TunnelConfig struct {
@@ -51,8 +54,18 @@ func (config *Config) setDefaults() {
 }
 
 // LoadConfiguration loads configuration from a YAML file
-func LoadConfiguration(config Config, subdomain string, port int, showWsReadErrors bool) (Config, error) {
-	var err error
+func LoadConfiguration(configFile string, subdomain string, port int, showWsReadErrors bool) (Config, error) {
+	var config Config
+
+	bytes, err := os.ReadFile(configFile)
+	if err != nil {
+		return Config{}, err
+	}
+
+	err = yaml.Unmarshal(bytes, &config)
+	if err != nil {
+		return Config{}, err
+	}
 
 	config.setDefaults()
 

--- a/client/connection.go
+++ b/client/connection.go
@@ -44,7 +44,7 @@ func NewConnection(pool *Pool) *Connection {
 // Connect to the IsolatorServer using a HTTP websocket
 func (connection *Connection) Connect(ctx context.Context) (err error) {
 	if connection.IsInitialConnection() {
-		log.Println("Creating tunnel connection")
+		log.Printf("Creating tunnel connection for :%d", connection.pool.client.Config.port)
 	}
 
 	var res *http.Response
@@ -92,11 +92,12 @@ func (connection *Connection) Connect(ctx context.Context) (err error) {
 	}
 
 	if connection.IsInitialConnection() {
-		log.Printf("Tunnel running on %s://%s.%s%s",
+		log.Printf("Tunnel connected %s://%s.%s%s -> http://localhost:%d",
 			httpScheme,
 			connection.pool.client.Config.subdomain,
 			URL.Hostname(),
 			httpPort,
+			connection.pool.client.Config.port,
 		)
 	}
 

--- a/client/connection.go
+++ b/client/connection.go
@@ -53,16 +53,16 @@ func (connection *Connection) Connect(ctx context.Context) (err error) {
 		ctx,
 		connection.pool.target,
 		http.Header{
-			"X-SECRET-KEY":       {connection.pool.client.Config.SecretKey},
-			"X-TUNNEL-SUBDOMAIN": {connection.pool.client.Config.subdomain},
+			"X-SECRET-KEY":       {connection.pool.client.Proxy.Config.SecretKey},
+			"X-TUNNEL-SUBDOMAIN": {connection.pool.client.Proxy.subdomain},
 			"X-LOCAL-SERVER": {fmt.Sprintf(
 				"http://localhost:%d",
-				connection.pool.client.Config.port,
+				connection.pool.client.Proxy.port,
 			)},
 			"X-GREETING-MESSAGE": {fmt.Sprintf(
 				"%s_%d",
-				connection.pool.client.Config.id,
-				connection.pool.client.Config.PoolIdleSize,
+				connection.pool.client.Proxy.id,
+				connection.pool.client.Proxy.Config.PoolIdleSize,
 			)},
 		},
 	)
@@ -94,7 +94,7 @@ func (connection *Connection) Connect(ctx context.Context) (err error) {
 	if connection.IsInitialConnection() {
 		log.Printf("Tunnel running on %s://%s.%s%s",
 			httpScheme,
-			connection.pool.client.Config.subdomain,
+			connection.pool.client.Proxy.subdomain,
 			URL.Hostname(),
 			httpPort,
 		)
@@ -133,7 +133,7 @@ func (connection *Connection) serve(ctx context.Context) {
 		connection.status = IDLE
 		_, jsonRequest, err := connection.ws.ReadMessage()
 		if err != nil {
-			if connection.pool.client.Config.showWsReadErrors {
+			if connection.pool.client.Proxy.showWsReadErrors {
 				log.Println("Unable to read request", err)
 			}
 			break
@@ -182,7 +182,11 @@ func (connection *Connection) serve(ctx context.Context) {
 			urlPath = urlPath + "?" + req.URL.RawQuery
 		}
 
-		log.Printf("[%s] %d %s", req.Method, resp.StatusCode, urlPath)
+		log.Printf("[%d] [%s] %d %s",
+			connection.pool.client.Proxy.port,
+			req.Method,
+			resp.StatusCode,
+			urlPath)
 
 		// Serialize response
 		jsonResponse, err := json.Marshal(beaver.SerializeHTTPResponse(resp))

--- a/client/connection.go
+++ b/client/connection.go
@@ -183,11 +183,11 @@ func (connection *Connection) serve(ctx context.Context) {
 			urlPath = urlPath + "?" + req.URL.RawQuery
 		}
 
-		log.Printf("[%d] [%s] %d %s",
-			connection.pool.client.Config.port,
+		log.Printf("[%s] %d %s",
 			req.Method,
 			resp.StatusCode,
-			urlPath)
+			urlPath,
+		)
 
 		// Serialize response
 		jsonResponse, err := json.Marshal(beaver.SerializeHTTPResponse(resp))

--- a/client/connection.go
+++ b/client/connection.go
@@ -53,16 +53,16 @@ func (connection *Connection) Connect(ctx context.Context) (err error) {
 		ctx,
 		connection.pool.target,
 		http.Header{
-			"X-SECRET-KEY":       {connection.pool.client.Proxy.Config.SecretKey},
-			"X-TUNNEL-SUBDOMAIN": {connection.pool.client.Proxy.subdomain},
+			"X-SECRET-KEY":       {connection.pool.client.Config.SecretKey},
+			"X-TUNNEL-SUBDOMAIN": {connection.pool.client.Config.subdomain},
 			"X-LOCAL-SERVER": {fmt.Sprintf(
 				"http://localhost:%d",
-				connection.pool.client.Proxy.port,
+				connection.pool.client.Config.port,
 			)},
 			"X-GREETING-MESSAGE": {fmt.Sprintf(
 				"%s_%d",
-				connection.pool.client.Proxy.id,
-				connection.pool.client.Proxy.Config.PoolIdleSize,
+				connection.pool.client.Config.id,
+				connection.pool.client.Config.PoolIdleSize,
 			)},
 		},
 	)
@@ -94,7 +94,7 @@ func (connection *Connection) Connect(ctx context.Context) (err error) {
 	if connection.IsInitialConnection() {
 		log.Printf("Tunnel running on %s://%s.%s%s",
 			httpScheme,
-			connection.pool.client.Proxy.subdomain,
+			connection.pool.client.Config.subdomain,
 			URL.Hostname(),
 			httpPort,
 		)
@@ -133,7 +133,7 @@ func (connection *Connection) serve(ctx context.Context) {
 		connection.status = IDLE
 		_, jsonRequest, err := connection.ws.ReadMessage()
 		if err != nil {
-			if connection.pool.client.Proxy.showWsReadErrors {
+			if connection.pool.client.Config.showWsReadErrors {
 				log.Println("Unable to read request", err)
 			}
 			break
@@ -183,7 +183,7 @@ func (connection *Connection) serve(ctx context.Context) {
 		}
 
 		log.Printf("[%d] [%s] %d %s",
-			connection.pool.client.Proxy.port,
+			connection.pool.client.Config.port,
 			req.Method,
 			resp.StatusCode,
 			urlPath)

--- a/client/pool.go
+++ b/client/pool.go
@@ -56,7 +56,7 @@ func (pool *Pool) connector(ctx context.Context) {
 	poolSize := pool.Size()
 
 	// Create enough connection to fill the pool
-	toCreate := pool.client.Proxy.Config.PoolIdleSize - poolSize.idle
+	toCreate := pool.client.Config.PoolIdleSize - poolSize.idle
 
 	// Create only one connection if the pool is empty
 	if poolSize.total == 0 {
@@ -64,8 +64,8 @@ func (pool *Pool) connector(ctx context.Context) {
 	}
 
 	// Ensure to open at most PoolMaxSize connections
-	if poolSize.total+toCreate > pool.client.Proxy.Config.PoolMaxSize {
-		toCreate = pool.client.Proxy.Config.PoolMaxSize - poolSize.total
+	if poolSize.total+toCreate > pool.client.Config.PoolMaxSize {
+		toCreate = pool.client.Config.PoolMaxSize - poolSize.total
 	}
 
 	// Try to reach ideal pool size

--- a/client/pool.go
+++ b/client/pool.go
@@ -56,7 +56,7 @@ func (pool *Pool) connector(ctx context.Context) {
 	poolSize := pool.Size()
 
 	// Create enough connection to fill the pool
-	toCreate := pool.client.Config.PoolIdleSize - poolSize.idle
+	toCreate := pool.client.Proxy.Config.PoolIdleSize - poolSize.idle
 
 	// Create only one connection if the pool is empty
 	if poolSize.total == 0 {
@@ -64,14 +64,14 @@ func (pool *Pool) connector(ctx context.Context) {
 	}
 
 	// Ensure to open at most PoolMaxSize connections
-	if poolSize.total+toCreate > pool.client.Config.PoolMaxSize {
-		toCreate = pool.client.Config.PoolMaxSize - poolSize.total
+	if poolSize.total+toCreate > pool.client.Proxy.Config.PoolMaxSize {
+		toCreate = pool.client.Proxy.Config.PoolMaxSize - poolSize.total
 	}
 
 	// Try to reach ideal pool size
 	for i := 0; i < toCreate; i++ {
 		conn := NewConnection(pool)
-		pool.connections = append(pool.connections, conn)
+		pool.add(conn)
 
 		go func() {
 			err := conn.Connect(ctx)

--- a/cmd/beaver_client/http.go
+++ b/cmd/beaver_client/http.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/amalshaji/beaver/client"
+	"github.com/spf13/cobra"
+)
+
+var (
+	port      int
+	subdomain string
+	httpCmd   = &cobra.Command{
+		Use:   "http [PORT]",
+		Short: "Tunnel local http servers",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("local server port is required")
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("only one port number is allowed")
+			}
+
+			var err error
+			port, err = strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("port must be a number")
+			}
+
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			var tunnels = make([]client.TunnelConfig, 0)
+			tunnels = append(tunnels, client.TunnelConfig{Port: port, Subdomain: subdomain})
+			startTunnels(tunnels)
+		},
+	}
+)
+
+func init() {
+	httpCmd.Flags().StringVar(&subdomain, "subdomain", "", "Subdomain to tunnel http requests (default \"<random_subdomain>\")")
+}

--- a/cmd/beaver_client/main.go
+++ b/cmd/beaver_client/main.go
@@ -2,43 +2,19 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/amalshaji/beaver/client"
-	flag "github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 )
 
-func getDefaultConfigFilePath() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-	return fmt.Sprintf("%s/.beaver/beaver_client.yaml", homeDir)
-}
-
-func loadProxyConfig(path string) (*client.Config, error) {
+func loadProxyConfig() (*client.Config, error) {
 	var config *client.Config
 
-	bytes, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	err = yaml.Unmarshal(bytes, &config)
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-func loadProxyTunnelConfig(path string) (*client.ProxyTunnels, error) {
-	var config *client.ProxyTunnels
-
-	bytes, err := os.ReadFile(path)
+	bytes, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, err
 	}
@@ -50,56 +26,17 @@ func loadProxyTunnelConfig(path string) (*client.ProxyTunnels, error) {
 	return config, nil
 }
 
-func main() {
+func startTunnels(tunnels []client.TunnelConfig) {
 	ctx := context.Background()
-
-	configFile := flag.String("config", getDefaultConfigFilePath(), "Config file path")
-	subdomain := flag.String("subdomain", "", "Subdomain to tunnel http requests (default \"<random_subdomain>\")")
-	port := flag.Int("port", 0, "Local http server port (required)")
-	startAll := flag.Bool("start-all", false, "Start all tunnels defined in config file")
-	showWsReadErrors := flag.Bool("showtunnelreaderrors", false, "Enable websocket read errors")
-
-	flag.CommandLine.MarkHidden("showtunnelreaderrors")
-
-	flag.CommandLine.SortFlags = false
-	flag.ErrHelp = fmt.Errorf("")
-
-	flag.Usage = func() {
-		fmt.Fprint(os.Stderr, "beaver - tunnel local ports to public URLs:\n\nUsage:\n")
-		flag.PrintDefaults()
-	}
-
-	flag.Parse()
-
 	var proxies []*client.Client
-	var tunnels *client.ProxyTunnels
 
-	proxyConfig, err := loadProxyConfig(*configFile)
+	proxyConfig, err := loadProxyConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if *startAll {
-		var err error
-		tunnels, err = loadProxyTunnelConfig(*configFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		if len(tunnels.Tunnels) == 0 {
-			log.Fatal("No tunnels defined in the config file")
-		}
-	} else {
-		if *port == 0 {
-			log.Fatalln("local server port is required")
-		}
-
-		if len(tunnels.Tunnels) != 0 {
-			tunnels.Tunnels = []client.TunnelConfig{{Subdomain: *subdomain, Port: *port}}
-		}
-	}
-
-	for _, proxyTunnel := range tunnels.Tunnels {
-		config, err := client.LoadConfiguration(*proxyConfig, proxyTunnel.Subdomain, proxyTunnel.Port, *showWsReadErrors)
+	for _, proxyTunnel := range tunnels {
+		config, err := client.LoadConfiguration(*proxyConfig, proxyTunnel.Subdomain, proxyTunnel.Port, showWsReadErrors)
 		if err != nil {
 			log.Fatalf("Unable to load configuration : %s", err)
 		}
@@ -117,5 +54,10 @@ func main() {
 	for _, proxy := range proxies {
 		proxy.Shutdown()
 	}
+}
 
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/beaver_client/main.go
+++ b/cmd/beaver_client/main.go
@@ -8,35 +8,14 @@ import (
 	"syscall"
 
 	"github.com/amalshaji/beaver/client"
-	"gopkg.in/yaml.v3"
 )
-
-func loadProxyConfig() (*client.Config, error) {
-	var config *client.Config
-
-	bytes, err := os.ReadFile(configFile)
-	if err != nil {
-		return nil, err
-	}
-
-	err = yaml.Unmarshal(bytes, &config)
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
-}
 
 func startTunnels(tunnels []client.TunnelConfig) {
 	ctx := context.Background()
 	var proxies []*client.Client
 
-	proxyConfig, err := loadProxyConfig()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	for _, proxyTunnel := range tunnels {
-		config, err := client.LoadConfiguration(*proxyConfig, proxyTunnel.Subdomain, proxyTunnel.Port, showWsReadErrors)
+		config, err := client.LoadConfiguration(configFile, proxyTunnel.Subdomain, proxyTunnel.Port, showWsReadErrors)
 		if err != nil {
 			log.Fatalf("Unable to load configuration : %s", err)
 		}

--- a/cmd/beaver_client/root.go
+++ b/cmd/beaver_client/root.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	configFile       string
+	showWsReadErrors bool
+	rootCmd          = &cobra.Command{
+		Use:   "beaver",
+		Short: "Tunnel local ports to public URLs",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+)
+
+func getDefaultConfigFilePath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s/.beaver/beaver_client.yaml", homeDir)
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&configFile, "config", getDefaultConfigFilePath(), "Path to the client config file")
+	rootCmd.PersistentFlags().BoolVar(&showWsReadErrors, "showWsReadErrors", false, "Log websocket read errors")
+
+	rootCmd.PersistentFlags().MarkHidden("showWsReadErrors")
+
+	rootCmd.AddCommand(startCmd)
+	rootCmd.AddCommand(httpCmd)
+}

--- a/cmd/beaver_client/start.go
+++ b/cmd/beaver_client/start.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/amalshaji/beaver/client"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	all      bool
+	startCmd = &cobra.Command{
+		Use:   "start [--all] or [tunnel1 tunnel2]",
+		Short: "Start tunnels defined in the config file",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if !all && len(args) == 0 {
+				return fmt.Errorf("either --all or a list of tunnel service names must be passed")
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			proxyTunnels, err := loadProxyTunnelConfig()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			var filteredTunnels = make([]client.TunnelConfig, 0)
+
+			if all {
+				filteredTunnels = proxyTunnels.Tunnels
+			} else {
+				tunnelsToStart := os.Args[2:]
+				for _, tunnel := range tunnelsToStart {
+					for _, proxyTunnel := range proxyTunnels.Tunnels {
+						if proxyTunnel.Name == tunnel {
+							filteredTunnels = append(filteredTunnels, proxyTunnel)
+						}
+					}
+				}
+			}
+
+			startTunnels(filteredTunnels)
+		},
+	}
+)
+
+func loadProxyTunnelConfig() (*client.ProxyTunnels, error) {
+	var config *client.ProxyTunnels
+
+	bytes, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(bytes, &config)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func init() {
+	startCmd.Flags().BoolVar(&all, "all", false, "Start all tunnels listed in the config")
+}

--- a/cmd/beaver_server/main.go
+++ b/cmd/beaver_server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 	"os/signal"
@@ -10,12 +9,9 @@ import (
 	"github.com/amalshaji/beaver/server"
 )
 
-func main() {
-	configFile := flag.String("config", "beaver_server.yaml", "config file path")
-	flag.Parse()
-
+func startServer() {
 	// Load configuration
-	config, err := server.LoadConfiguration(*configFile)
+	config, err := server.LoadConfiguration(configFile)
 	if err != nil {
 		log.Fatalf("Unable to load configuration : %s", err)
 	}
@@ -30,4 +26,10 @@ func main() {
 
 	// When receives the signal, shutdown
 	server.Shutdown()
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/beaver_server/root.go
+++ b/cmd/beaver_server/root.go
@@ -1,0 +1,18 @@
+package main
+
+import "github.com/spf13/cobra"
+
+var (
+	configFile string
+	rootCmd    = &cobra.Command{
+		Use:   "beaver_server",
+		Short: "Tunnel local ports to public URLs",
+		Run: func(cmd *cobra.Command, args []string) {
+			startServer()
+		},
+	}
+)
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&configFile, "config", "beaver_server.yaml", "Path to config file")
+}

--- a/docs/beaver_client.yaml
+++ b/docs/beaver_client.yaml
@@ -1,5 +1,12 @@
-targets :                            # Endpoints to connect to
- - ws://localhost:8080
-poolidlesize : 1                     # Default number of concurrent open (TCP) connections to keep idle per WSP server
-poolmaxsize : 100                    # Maximum number of concurrent open (TCP) connections per WSP server
-secretkey : ThisIsASecret          # secret key that must match the value set in servers configuration
+config:
+  targets: # Endpoints to connect to
+    - ws://localhost:8080
+  poolidlesize: 1 # Default number of concurrent open (TCP) connections to keep idle per WSP server
+  poolmaxsize: 100 # Maximum number of concurrent open (TCP) connections per WSP server
+  secretkey: ThisIsASecret # secret key that must match the value set in servers configuration
+
+tunnels:
+  - subdomain:
+    port: 8000
+  - subdomain:
+    port: 9000

--- a/docs/beaver_client.yaml
+++ b/docs/beaver_client.yaml
@@ -1,12 +1,11 @@
-config:
-  targets: # Endpoints to connect to
-    - ws://localhost:8080
-  poolidlesize: 1 # Default number of concurrent open (TCP) connections to keep idle per WSP server
-  poolmaxsize: 100 # Maximum number of concurrent open (TCP) connections per WSP server
-  secretkey: ThisIsASecret # secret key that must match the value set in servers configuration
-
+target: wss://x.amal.sh # Endpoints to connect to
+poolidlesize: 1 # Default number of concurrent open (TCP) connections to keep idle per WSP server
+poolmaxsize: 100 # Maximum number of concurrent open (TCP) connections per WSP server
+secretkey: ThisIsASecret # secret key that must match the value set in servers configuration
 tunnels:
-  - subdomain:
+  - name: tp1
+    subdomain:
     port: 8000
-  - subdomain:
+  - name: tp2
+    subdomain:
     port: 9000

--- a/docs/beaver_client.yaml
+++ b/docs/beaver_client.yaml
@@ -4,8 +4,8 @@ poolmaxsize: 100 # Maximum number of concurrent open (TCP) connections per WSP s
 secretkey: ThisIsASecret # secret key that must match the value set in servers configuration
 tunnels:
   - name: tp1 # Tunnel name
-    subdomain: # Subdomain to create the tunnel connection at (optional)
+    subdomain: test-subdomain-1 # Subdomain to create the tunnel connection at (optional)
     port: 8000 # Local server port
   - name: tp2
-    subdomain:
+    subdomain: test-subdomain-1
     port: 9000

--- a/docs/beaver_client.yaml
+++ b/docs/beaver_client.yaml
@@ -1,4 +1,4 @@
-target: wss://x.amal.sh # Endpoints to connect to
+target: ws://localhost:8080 # Endpoints to connect to
 poolidlesize: 1 # Default number of concurrent open (TCP) connections to keep idle per WSP server
 poolmaxsize: 100 # Maximum number of concurrent open (TCP) connections per WSP server
 secretkey: ThisIsASecret # secret key that must match the value set in servers configuration

--- a/docs/beaver_client.yaml
+++ b/docs/beaver_client.yaml
@@ -3,9 +3,9 @@ poolidlesize: 1 # Default number of concurrent open (TCP) connections to keep id
 poolmaxsize: 100 # Maximum number of concurrent open (TCP) connections per WSP server
 secretkey: ThisIsASecret # secret key that must match the value set in servers configuration
 tunnels:
-  - name: tp1
-    subdomain:
-    port: 8000
+  - name: tp1 # Tunnel name
+    subdomain: # Subdomain to create the tunnel connection at (optional)
+    port: 8000 # Local server port
   - name: tp2
     subdomain:
     port: 9000

--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,16 @@ require (
 	github.com/labstack/echo/v4 v4.10.0
 	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/cobra v1.6.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -25,6 +29,9 @@ github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
⚠️ Breaking change

This PR breaks the client config format. It introduces a new field to the config, `tunnels`, describing multiple tunnel connections.  

```yaml
target: wss://x.amal.sh
secretkey: ThisIsASecret
tunnels:
  - name: tp1
    subdomain:
    port: 8000
  - name: tp2
    subdomain:
    port: 9000
```

## Demo

Here, the subdomains are left empty

[![asciicast](https://asciinema.org/a/klPlmhEviOWAY3mdBhIFiSJx3.svg)](https://asciinema.org/a/klPlmhEviOWAY3mdBhIFiSJx3)